### PR TITLE
add the prometheus node exporter to validator nodes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,7 @@ terraform-destroy:
 
 ansible-install:
 	cd ansible && ansible-playbook -i hosts -u root base.yaml -f 10
+	cd ansible && ansible-playbook -i hosts -u root prometheus-node-exporter.yaml -f 10
 	cd ansible && ansible-playbook -i hosts -u root init-testapp.yaml -f 10
 	cd ansible && ansible-playbook -i hosts -u root update-testapp.yaml -f 10
 

--- a/ansible/base.yaml
+++ b/ansible/base.yaml
@@ -4,7 +4,7 @@
   become_method: sudo
   vars:
     ansible_host_key_checking: false
- 
+
   tasks:
     - name: Update apt cache
       ansible.builtin.apt:
@@ -17,5 +17,6 @@
           - gcc
           - golang-1.17-go
           - prometheus
+          - prometheus-node-exporter
         state: latest
       become: yes

--- a/ansible/prometheus-node-exporter.yaml
+++ b/ansible/prometheus-node-exporter.yaml
@@ -1,0 +1,19 @@
+- name: prometheus node exporter
+  hosts: validators,prometheus
+  gather_facts: yes
+  become_method: sudo
+  vars:
+    ansible_host_key_checking: false
+
+  tasks:
+    - name: add node-exporter systemd unit file
+      ansible.builtin.copy:
+        src: templates/prometheus-node-exporter.service
+        dest: /etc/prometheus/prometheus-node-exporter.service
+      become: yes
+    - name: start the systemd unit
+      ansible.builtin.systemd:
+        name: prometheus-node-exporter
+        state: started
+        daemon_reload: yes
+        enabled: yes

--- a/ansible/templates/prometheus-node-exporter.service
+++ b/ansible/templates/prometheus-node-exporter.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Node Exporter
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+User=prometheus
+Group=prometheus
+Type=simple
+ExecStart=/usr/bin/prometheus-node-exporter
+
+[Install]
+WantedBy=multi-user.target

--- a/ansible/templates/prometheus.yml.j2
+++ b/ansible/templates/prometheus.yml.j2
@@ -6,10 +6,16 @@ scrape_configs:
 {% for host in groups['validators'] %}
   - job_name: {{ hostvars[host].name }}
 
-    # Override the global default and scrape targets from this job every 5 seconds.
     scrape_interval: 5s
 
     static_configs:
       - targets: ['{{ hostvars[host].inventory_hostname }}:26660']
+
+  - job_name: {{ hostvars[host].name }}-node-exporter
+
+    scrape_interval: 5s
+
+    static_configs:
+      - targets: ['{{ hostvars[host].inventory_hostname }}:9100']
 
 {% endfor %}


### PR DESCRIPTION
This PR adds an ansible playbook for creating and starting the prometheus node-exporter. A systemd unit file is added for the node exporter and then started as part of the new `prometheus-node-exporter` playbook.

This PR also modifies the templatized prometheus scrape targets to add the exporter endpoint.