### PR TITLE
Install ntp

### DIFF
--- a/ansible/base.yaml
+++ b/ansible/base.yaml
@@ -18,5 +18,7 @@
           - golang-1.17-go
           - prometheus
           - prometheus-node-exporter
+          - ntp
+          - ntpstat
         state: latest
       become: yes


### PR DESCRIPTION
Simplistic approach: just apt intall ntp, with default config.

Tested it and servers' NTP state is "syncing"