### PR TITLE
factor down the number of find targets

### DIFF
--- a/script/configgen.sh
+++ b/script/configgen.sh
@@ -13,10 +13,11 @@ SEED_IPS=$3
 go run github.com/tendermint/tendermint/test/e2e/runner@$VERSION setup -f ./testnet.toml
 OLD_IPS=`grep -E '(ipv4_address|container_name)' ./testnet/docker-compose.yml | sed 's/^.*ipv4_address: \(.*\)/\1/g' | sed 's/.*container_name: \(.*\)/\1/g' | paste -sd ' \n' - | sort -k1 | cut -d ' ' -f2`
 
-while read old <&3 && read new <&4; do
-	find ./testnet/ -type f | xargs -I{} sed $INPLACE_SED_FLAG "s/\b$old\b/$new/g" {}
-done 3< <(echo $OLD_IPS | tr ' ' '\n') 4< <(echo $NEW_IPS | tr , '\n' ) 
-
+for file in `find ./testnet/ -name config.toml -type f`; do
+	while read old <&3 && read new <&4; do
+		sed $INPLACE_SED_FLAG "s/\b$old\b/$new/g" $file
+	done 3< <(echo $OLD_IPS | tr ' ' '\n') 4< <(echo $NEW_IPS | tr , '\n' )
+done
 
 # Seed nodes end up with many outgoing persistent peers. Tendermint has an
 # Upperbound on how many persistent peers it can have. We reduce the set of persistent


### PR DESCRIPTION
Re-running find and giving it an overbroad set of files resulted in the `configgen.sh` going incredibly slowly on large testnets.

This only runs the find operation one time and on a smaller set of files.